### PR TITLE
fix(announce): remove obsolete check for Server header

### DIFF
--- a/src/Instana/SDK/Internal/Logging.hs
+++ b/src/Instana/SDK/Internal/Logging.hs
@@ -197,6 +197,7 @@ parseLogLevel logLevelStr =
     "INFO"      -> Just INFO
     "NOTICE"    -> Just NOTICE
     "WARNING"   -> Just WARNING
+    "WARN"      -> Just WARNING
     "ERROR"     -> Just ERROR
     "CRITICAL"  -> Just CRITICAL
     "ALERT"     -> Just ALERT

--- a/test/agent-stub/Instana/SDK/AgentStub/API.hs
+++ b/test/agent-stub/Instana/SDK/AgentStub/API.hs
@@ -14,7 +14,7 @@ import           Instana.SDK.AgentStub.TraceRequest      (TraceRequest)
 
 type API =
        -- GET /
-       Get '[JSON] (Headers '[Header "Server" String] NoContent)
+       Get '[JSON] NoContent
 
        -- PUT /com.instana.plugin.haskell.discovery
   :<|> "com.instana.plugin.haskell.discovery"

--- a/test/agent-stub/Instana/SDK/AgentStub/Server.hs
+++ b/test/agent-stub/Instana/SDK/AgentStub/Server.hs
@@ -10,8 +10,7 @@ import           Data.Maybe                              (fromMaybe)
 import           Data.STRef                              (modifySTRef,
                                                           readSTRef)
 import           Data.Time.Clock.POSIX                   (getPOSIXTime)
-import           Servant                                 (Header, Headers,
-                                                          NoContent (NoContent),
+import           Servant                                 (NoContent (NoContent),
                                                           err404, err503,
                                                           (:<|>) (..))
 import qualified Servant
@@ -50,9 +49,9 @@ mainServer config startupTime recorders =
  :<|> StubServer.stubServer recorders
 
 
-getRoot :: Servant.Handler (Headers '[Header "Server" String] NoContent)
+getRoot :: Servant.Handler NoContent
 getRoot =
-  return $ Servant.addHeader "Instana Agent" NoContent
+  return $ NoContent
 
 
 putDiscovery ::

--- a/test/integration/Instana/SDK/IntegrationTest/Connection.hs
+++ b/test/integration/Instana/SDK/IntegrationTest/Connection.hs
@@ -13,9 +13,9 @@ import           Test.HUnit
 
 import           Instana.SDK.AgentStub.TraceRequest     (From (..), Span)
 import qualified Instana.SDK.AgentStub.TraceRequest     as TraceRequest
-import qualified Instana.SDK.IntegrationTest.HttpHelper as HttpHelper
 import           Instana.SDK.IntegrationTest.HUnitExtra (applyLabel,
                                                          assertAllIO, failIO)
+import qualified Instana.SDK.IntegrationTest.HttpHelper as HttpHelper
 import qualified Instana.SDK.IntegrationTest.Suite      as Suite
 import qualified Instana.SDK.IntegrationTest.TestHelper as TestHelper
 

--- a/test/integration/Instana/SDK/IntegrationTest/HttpHelper.hs
+++ b/test/integration/Instana/SDK/IntegrationTest/HttpHelper.hs
@@ -41,8 +41,8 @@ retryDelay = 100 * 1000
 --    simultaneously
 -- 2) The agent stub might not yet be up when the Instana SDK in the app under
 --    test starts to look for an agent (which is a perfectly normal situation
---    and should shouldn't not be a problem as the SDK will retry with to find
---    an agent to connect to with fibonacci backoff).
+--    and should shouldn't not be a problem as the SDK will retry to find an
+--    agent to connect to with fibonacci backoff).
 -- 3) When this happens, the first attempt to talk to 127.0.0.1:1302 fails.
 -- 4) Next, the SDK attempts to talk to an agent over the default gateway.
 -- 5) This never happens locally (at least not on MacOS), as there is no


### PR DESCRIPTION
This check actually breaks the announce procedure if a service mesh with proxies is present, as the proxy might very well be configured to replace the Instana agent's Server header with its own. The check is superfluous anyway. Instead, the trace SDK now checks whether the HTTP status code is in the 2xx range.