### PR TITLE
refactor: remove dependency on sbin and awk in containers

### DIFF
--- a/instana-haskell-trace-sdk.cabal
+++ b/instana-haskell-trace-sdk.cabal
@@ -47,13 +47,13 @@ library
     , http-client-tls
     , http-types
     , network
-    , process
     , random
     , regex-base
     , regex-compat
     , regex-pcre
     , regex-tdfa
     , retry
+    , safe
     , scientific
     , stm
     , sysinfo
@@ -87,6 +87,7 @@ library
       Instana.SDK.Internal.AgentConnection.AgentReady
       Instana.SDK.Internal.AgentConnection.Announce
       Instana.SDK.Internal.AgentConnection.ConnectLoop
+      Instana.SDK.Internal.AgentConnection.DefaultGatewayIp
       Instana.SDK.Internal.AgentConnection.Json.AnnounceResponse
       Instana.SDK.Internal.AgentConnection.Json.Util
       Instana.SDK.Internal.AgentConnection.Paths
@@ -168,6 +169,7 @@ test-suite instana-haskell-trace-sdk-unit-tests
     , regex-compat
     , regex-pcre
     , regex-tdfa
+    , safe
     , scientific
     , text
     , unordered-containers
@@ -175,6 +177,7 @@ test-suite instana-haskell-trace-sdk-unit-tests
     , wai
   other-modules:
       -- the actual tests
+      Instana.SDK.Internal.AgentConnection.DefaultGatewayIpTest
       Instana.SDK.Internal.AgentConnection.SchedFileTest
       Instana.SDK.Internal.ConfigTest
       Instana.SDK.Internal.IdTest
@@ -190,6 +193,7 @@ test-suite instana-haskell-trace-sdk-unit-tests
       Instana.SDK.TracingHeadersTest
       -- modules under test
       Instana.SDK.Internal.Config
+      Instana.SDK.Internal.AgentConnection.DefaultGatewayIp
       Instana.SDK.Internal.AgentConnection.SchedFile
       Instana.SDK.Internal.Id
       Instana.SDK.Internal.Logging

--- a/src/Instana/SDK/Internal/AgentConnection/DefaultGatewayIp.hs
+++ b/src/Instana/SDK/Internal/AgentConnection/DefaultGatewayIp.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-|
+Module      : Instana.SDK.Internal.AgentConnection.DefaultGatewayIp
+Description : Extracts the default gateway IP from the content of /proc/self/net/route.
+-}
+module Instana.SDK.Internal.AgentConnection.DefaultGatewayIp
+    ( extractDefaultGatewayIp
+    ) where
+
+import           Control.Monad (join)
+import qualified Data.List     as List
+import           Data.Text     (Text)
+import qualified Data.Text     as T
+import           Numeric       (readHex)
+import           Safe          (atMay)
+
+
+-- |Parses the content of /proc/self/net/route to retrieve the IP of the default
+-- gateway.
+extractDefaultGatewayIp :: String -> Maybe String
+extractDefaultGatewayIp routeFileContent =
+  let
+    allLines = lines routeFileContent
+    linesAsFields = map (\l -> T.splitOn "\t" $ T.pack l) allLines
+    lineWithDefaultGateway = List.find isDefaultGatewayLine linesAsFields
+    ip = join $ fmap extractIpFromFields lineWithDefaultGateway
+  in
+  fmap T.unpack ip
+
+
+isDefaultGatewayLine :: [Text] -> Bool
+isDefaultGatewayLine fields =
+  let
+    field2 = atMay fields 1
+    lenField3 = fmap T.length $ atMay fields 2
+  in
+  length fields >= 3 &&
+    field2 == Just "00000000" &&
+    lenField3 == Just 8
+
+
+extractIpFromFields :: [Text] -> Maybe Text
+extractIpFromFields fields =
+  fmap convertHexStringToIp $ atMay fields 2
+
+
+convertHexStringToIp :: Text -> Text
+convertHexStringToIp hexstring =
+  let
+    o1 = substringLength2 6 hexstring
+    o2 = substringLength2 4 hexstring
+    o3 = substringLength2 2 hexstring
+    o4 = T.take 2 hexstring
+  in
+  T.intercalate "." $ map hexstringToDecimal [o1, o2, o3, o4]
+
+
+substringLength2 :: Int -> Text -> Text
+substringLength2 start =
+  T.take 2 . T.drop start
+
+
+hexstringToDecimal :: Text -> Text
+hexstringToDecimal hexstring =
+  let
+    result = readHex $ T.unpack hexstring
+  in
+  case result of
+      (x,_):_ -> T.pack $ show (x :: Int)
+      _       -> "0"

--- a/test/integration/Instana/SDK/IntegrationTest/HttpHelper.hs
+++ b/test/integration/Instana/SDK/IntegrationTest/HttpHelper.hs
@@ -45,15 +45,15 @@ retryDelay = 100 * 1000
 --    agent to connect to with fibonacci backoff).
 -- 3) When this happens, the first attempt to talk to 127.0.0.1:1302 fails.
 -- 4) Next, the SDK attempts to talk to an agent over the default gateway.
--- 5) This never happens locally (at least not on MacOS), as there is no
---    /sbin/ip executable present
--- 6) On Travis (or more generally on most Linux systems), the SDK actually
---    tries the default gateway because that executable _is_ present. It will
+-- 5) This never happens locally (at least not on MacOS), since the file
+--    /proc/self/net/route does not exist.
+-- 6) On CircleCI (or more generally on most Linux systems), the SDK actually
+--    tries the default gateway because that file _is_ present. It will
 --    also find a default gateway (let's say, for example, 10.20.0.1).
 -- 7) That host is reachable so an HTTP request to 10.20.0.1:1302 is attempted
 --    (1302 is the configured agent port in the integration tests).
 -- 8) If something exists at 10.20.0.1:1302 it never sends a response. Or there
---    is nothing there but somehow the request does not fail immediately.
+--    is nothing there but the request only fails after the connection timeout.
 --    Either way, trying this HTTP request eats up around 5 seconds. Why 5
 --    seconds? 5 seconds is:
 --    a) the timeout the SDK sets itself (see Instana/SDK/SDK.hs, value for

--- a/test/unit/Instana/SDK/Internal/AgentConnection/DefaultGatewayIpTest.hs
+++ b/test/unit/Instana/SDK/Internal/AgentConnection/DefaultGatewayIpTest.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Instana.SDK.Internal.AgentConnection.DefaultGatewayIpTest (allTests) where
+
+
+import           Test.HUnit
+
+import           Instana.SDK.Internal.AgentConnection.DefaultGatewayIp (extractDefaultGatewayIp)
+
+
+allTests :: Test
+allTests =
+  TestList
+    [ TestLabel "shouldExtractDefaultGatewayIpFromFile" shouldExtractDefaultGatewayIpFromFile
+    , TestLabel "shouldNotExtractFromEmptyFile" shouldNotExtractFromEmptyFile
+    , TestLabel "shouldNotExtractFromLinesWithTooFewFields" shouldNotExtractFromLinesWithTooFewFields
+    , TestLabel "shouldNotExtractIfNoLineHas8Zeroes" shouldNotExtractIfNoLineHas8Zeroes
+    , TestLabel "shouldNotExtractIfThirdFieldHasWrongLength" shouldNotExtractIfThirdFieldHasWrongLength
+    , TestLabel "shouldCopeWithThirdFieldNotAHexString" shouldCopeWithThirdFieldNotAHexString
+    ]
+
+
+shouldExtractDefaultGatewayIpFromFile :: Test
+shouldExtractDefaultGatewayIpFromFile =
+  let
+    defaultGatewayIp =
+      extractDefaultGatewayIp $
+        "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetricMask\tMTU\tWindow\tIRTT\n" ++
+        "eth0\t0000F1AC\t00000000\t0001\t0\t0\t0\t0000FFFF0\t0\t0\n" ++
+        "eth0\t00000000\t010011AC\t0003\t0\t0\t0\t000000000\t0\t0\n" ++
+        "eth0\t000011AC\t00000000\t0001\t0\t0\t0\t0000FFFF0\t0\t0"
+  in
+  TestCase $
+    assertEqual "default gateway IP" (Just "172.17.0.1") defaultGatewayIp
+
+
+shouldNotExtractFromEmptyFile :: Test
+shouldNotExtractFromEmptyFile =
+  let
+    defaultGatewayIp = extractDefaultGatewayIp ""
+  in
+  TestCase $
+    assertEqual "default gateway IP" Nothing defaultGatewayIp
+
+
+shouldNotExtractFromLinesWithTooFewFields :: Test
+shouldNotExtractFromLinesWithTooFewFields =
+  let
+    defaultGatewayIp =
+      extractDefaultGatewayIp $
+        "Iface\tDestination\n" ++
+        "eth0\t00000000"
+  in
+  TestCase $
+    assertEqual "default gateway IP" Nothing defaultGatewayIp
+
+
+shouldNotExtractIfNoLineHas8Zeroes :: Test
+shouldNotExtractIfNoLineHas8Zeroes =
+  let
+    defaultGatewayIp =
+      extractDefaultGatewayIp $
+        "eth0\t00009000\t010011AC\t0003\t0\t0\t0\t000000000\t0\t0"
+  in
+  TestCase $
+    assertEqual "default gateway IP" Nothing defaultGatewayIp
+
+
+shouldNotExtractIfThirdFieldHasWrongLength :: Test
+shouldNotExtractIfThirdFieldHasWrongLength =
+  let
+    defaultGatewayIp =
+      extractDefaultGatewayIp $
+        "eth0\t00000000\t010011A\t0003\t0\t0\t0\t000000000\t0\t0"
+  in
+  TestCase $
+    assertEqual "default gateway IP" Nothing defaultGatewayIp
+
+
+shouldCopeWithThirdFieldNotAHexString :: Test
+shouldCopeWithThirdFieldNotAHexString =
+  let
+    defaultGatewayIp =
+      extractDefaultGatewayIp $
+        "eth0\t00000000\tghijklmn\t0003\t0\t0\t0\t000000000\t0\t0"
+  in
+  TestCase $
+    assertEqual "default gateway IP" (Just "0.0.0.0") defaultGatewayIp

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -1,19 +1,20 @@
 module Main where
 
 
-import qualified Instana.SDK.Internal.AgentConnection.SchedFileTest as SchedFileTest
-import qualified Instana.SDK.Internal.ConfigTest                    as ConfigTest
-import qualified Instana.SDK.Internal.IdTest                        as IdTest
-import qualified Instana.SDK.Internal.LoggingTest                   as LoggingTest
-import qualified Instana.SDK.Internal.Metrics.CompressionTest       as MetricsCompressionTest
-import qualified Instana.SDK.Internal.Metrics.DeltasTest            as MetricsDeltasTest
-import qualified Instana.SDK.Internal.SecretsTest                   as SecretsTest
-import qualified Instana.SDK.Internal.ServerTimingTest              as ServerTimingTest
-import qualified Instana.SDK.Internal.SpanStackTest                 as SpanStackTest
-import qualified Instana.SDK.Internal.W3CTraceContextTest           as W3CTraceContextTest
-import qualified Instana.SDK.SpanDataTest                           as SpanDataTest
-import qualified Instana.SDK.SpanTest                               as SpanTest
-import qualified Instana.SDK.TracingHeadersTest                     as TracingHeadersTest
+import qualified Instana.SDK.Internal.AgentConnection.DefaultGatewayIpTest as DefaultGatewayIpTest
+import qualified Instana.SDK.Internal.AgentConnection.SchedFileTest        as SchedFileTest
+import qualified Instana.SDK.Internal.ConfigTest                           as ConfigTest
+import qualified Instana.SDK.Internal.IdTest                               as IdTest
+import qualified Instana.SDK.Internal.LoggingTest                          as LoggingTest
+import qualified Instana.SDK.Internal.Metrics.CompressionTest              as MetricsCompressionTest
+import qualified Instana.SDK.Internal.Metrics.DeltasTest                   as MetricsDeltasTest
+import qualified Instana.SDK.Internal.SecretsTest                          as SecretsTest
+import qualified Instana.SDK.Internal.ServerTimingTest                     as ServerTimingTest
+import qualified Instana.SDK.Internal.SpanStackTest                        as SpanStackTest
+import qualified Instana.SDK.Internal.W3CTraceContextTest                  as W3CTraceContextTest
+import qualified Instana.SDK.SpanDataTest                                  as SpanDataTest
+import qualified Instana.SDK.SpanTest                                      as SpanTest
+import qualified Instana.SDK.TracingHeadersTest                            as TracingHeadersTest
 
 import           Test.HUnit
 
@@ -27,6 +28,7 @@ allTests :: Test
 allTests =
   TestList
     [ ConfigTest.allTests
+    , DefaultGatewayIpTest.allTests
     , IdTest.allTests
     , LoggingTest.allTests
     , MetricsCompressionTest.allTests
@@ -34,9 +36,9 @@ allTests =
     , SchedFileTest.allTests
     , SecretsTest.allTests
     , ServerTimingTest.allTests
+    , SpanDataTest.allTests
     , SpanStackTest.allTests
     , SpanTest.allTests
-    , SpanDataTest.allTests
     , TracingHeadersTest.allTests
     , W3CTraceContextTest.allTests
     ]


### PR DESCRIPTION
Read the default gateway IP from /proc/self/net/route instead of using sbin and awk. These two executables are not always available, depending on the container base image.